### PR TITLE
intregration_pycairo.py: remove geometry import

### DIFF
--- a/examples/integration_pycairo.py
+++ b/examples/integration_pycairo.py
@@ -13,7 +13,6 @@ from array import array
 
 import cairo
 import moderngl
-from moderngl_window import geometry
 from ported._example import Example
 
 


### PR DESCRIPTION
### Description

In examples/integration_pycairo.py, there was an import which didn't seem to be used.

### List of changes

- **removed** the import of moderngl_window.geometry

<!--

### Style for python files:

- Please use 4 spaces (not tabs).
- Please follow the pep8 style guide.

-->

<!-- Please add yourself to the README.md too! -->
